### PR TITLE
update import to reflect network ActionModule move into netcommon collection

### DIFF
--- a/plugins/action/onyx_config.py
+++ b/plugins/action/onyx_config.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 
 
 class ActionModule(ActionNetworkModule):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the import for ActionModule to reflect the new location after creation of ansible_collections.ansible.netcommon.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
onyx_config

##### ADDITIONAL INFORMATION
Solution was actually provided by the collection maintainer. Creating pull request to merge actual code.