### PR TITLE
Fix module name in documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Another option is to call modules by their short name if you list the `mellanox.
     - mellanox.onyx
 
   tasks:
-	- name: configure link aggregation group
-	  onyx_linkagg:
-	    name: Po1
-	    members:
-	      - Eth1/1
-	      - Eth1/2
+  - name: configure link aggregation group
+    onyx_linkagg:
+      name: Po1
+      members:
+        - Eth1/1
+        - Eth1/2
 ```
 
 

--- a/plugins/modules/onyx_ntp_servers_peers.py
+++ b/plugins/modules/onyx_ntp_servers_peers.py
@@ -83,7 +83,7 @@ options:
 
 EXAMPLES = """
 - name: Configure NTP peers and servers
-  onyx_ntp_peers_servers:
+  onyx_ntp_servers_peers:
     peer:
        - ip_or_name: 1.1.1.1
          enabled: yes


### PR DESCRIPTION
##### SUMMARY
Fixes misspelled module name in documentation example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`onyx_ntp_servers_peers`

##### ADDITIONAL INFORMATION

