### PR TITLE
Fixes missing vni flag needed in the EVPN auto-create command

### DIFF
--- a/plugins/modules/onyx_bgp.py
+++ b/plugins/modules/onyx_bgp.py
@@ -111,7 +111,7 @@ commands:
     - router bgp 320 vrf default neighbor evpn send-community extended
     - router bgp 320 vrf default address-family l2vpn-evpn neighbor evpn next-hop-unchanged
     - router bgp 320 vrf default address-family l2vpn-evpn neighbor evpn activate
-    - router bgp 320 vrf default address-family l2vpn-evpn auto-create
+    - router bgp 320 vrf default address-family l2vpn-evpn vni auto-create
     - router bgp 320 vrf default neighbor 10.3.3.4 remote-as 321
     - router bgp 320 vrf default neighbor 10.3.3.4 ebgp-multihop 250
     - router bgp 320 vrf default neighbor 10.3.3.5 remote-as 322
@@ -152,7 +152,7 @@ class OnyxBgpModule(BaseOnyxModule):
     EVPN_ACTIVATE_REGEX = re.compile(
         r'^\s.*router bgp\s+(\d+)\s+vrf\s+(\S+)\s+address-family l2vpn\-evpn neighbor evpn activate.*')
     EVPN_AUTO_CREATE_REGEX = re.compile(
-        r'^\s.*router bgp\s+(\d+)\s+vrf\s+(\S+)\s+address-family l2vpn\-evpn auto-create.*')
+        r'^\s.*router bgp\s+(\d+)\s+vrf\s+(\S+)\s+address-family l2vpn\-evpn vni auto-create.*')
 
     _purge = False
 
@@ -166,7 +166,7 @@ class OnyxBgpModule(BaseOnyxModule):
     EVPN_SEND_COMMUNITY_EXTENDED_CMD = "router bgp %s vrf %s neighbor evpn send-community extended"
     EVPN_NEXT_HOP_UNCHANGED_CMD = "router bgp %s vrf %s address-family l2vpn-evpn neighbor evpn next-hop-unchanged"
     EVPN_ACTIVATE_CMD = "router bgp %s vrf %s address-family l2vpn-evpn neighbor evpn activate"
-    EVPN_AUTO_CREATE_CMD = "router bgp %s vrf %s address-family l2vpn-evpn auto-create"
+    EVPN_AUTO_CREATE_CMD = "router bgp %s vrf %s address-family l2vpn-evpn vni auto-create"
 
     EVPN_ENABLE_ATTRS = [EVPN_PEER_GROUP_ATTR, EVPN_SEND_COMMUNITY_EXTENDED_ATTR,
                          EVPN_NEXT_HOP_UNCHANGED_ATTR, EVPN_ACTIVATE_ATTR, EVPN_AUTO_CREATE_ATTR]


### PR DESCRIPTION
Signed-off-by: SniffedPacket <cmatlockusmc@gmail.com>

##### SUMMARY
Fixes missing "vni" option needed in the EVPN auto-create command. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mellanox.onyx.onyx_bgp


##### ADDITIONAL INFORMATION
Correct syntax according to the user guide.

https://docs.nvidia.com/networking/pages/viewpage.action?pageId=56986441#heading-BGPandEVPNConfiguration

```
router bgp 65001 vrf default neighbor evpn peer-group
router bgp 65001 vrf default neighbor evpn send-community
router bgp 65001 vrf default neighbor evpn send-community extended
router bgp 65001 vrf default address-family l2vpn-evpn neighbor evpn next-hop-unchanged
router bgp 65001 vrf default address-family l2vpn-evpn neighbor evpn activate
router bgp 65001 vrf default address-family l2vpn-evpn **vni** auto-create    <<<<<<<
router bgp 65001 vrf default neighbor 10.10.10.1 peer-group evpn
router bgp 65001 vrf default neighbor 100.100.100.1 peer-group evpn
router bgp 65001 vrf default neighbor 100.100.100.5 peer-group evpn
```

As of now if you use the `evpn: yes` option in the BGP module, it will error out when it gets to the l2vpn-evpn auto-create command.

Output result before fix:

```
TASK [vxlan_underlay : Configure BGP session to spines] **************************************************************************************************************
task path: /home/cumulus/Onyx_Lab/roles/vxlan_underlay/tasks/main.yml:19
Friday 11 March 2022  16:23:42 -0500 (0:00:02.627)       0:02:48.013 **********
<10.188.71.129> ESTABLISH LOCAL CONNECTION FOR USER: cumulus
<10.188.71.129> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs `"&& mkdir "` echo /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343 `" && echo ansible-tmp-1647033822.168955-11112-33330374825343="` echo /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343 `" ) && sleep 0'
Using module file /home/cumulus/onyx_test/lib/python3.8/site-packages/ansible/modules/network/onyx/onyx_bgp.py
<10.188.71.129> PUT /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/tmpltrbwjxm TO /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343/AnsiballZ_onyx_bgp.py
<10.188.71.129> EXEC /bin/sh -c 'chmod u+x /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343/ /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343/AnsiballZ_onyx_bgp.py && sleep 0'
<10.188.71.129> EXEC /bin/sh -c '/usr/bin/python3 /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343/AnsiballZ_onyx_bgp.py && sleep 0'
<10.188.71.129> EXEC /bin/sh -c 'rm -f -r /home/cumulus/.ansible/tmp/ansible-local-103697aeyf5gs/ansible-tmp-1647033822.168955-11112-33330374825343/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
  File "/tmp/ansible_onyx_bgp_payload_3o802lz5/ansible_onyx_bgp_payload.zip/ansible/module_utils/network/onyx/onyx.py", line 77, in load_config
    conn.edit_config(config)
  File "/tmp/ansible_onyx_bgp_payload_3o802lz5/ansible_onyx_bgp_payload.zip/ansible/module_utils/connection.py", line 185, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
failed: [mlx-2740-51] (item={'name': 'Eth1/14', 'ipv4': '9.9.9.1/24', 'bgp_neigh': '9.9.9.2'}) => changed=false
  ansible_loop_var: item
  invocation:
    module_args:
      as_number: 65001
      ecmp_bestpath: true
      evpn: true
      fast_external_fallover: true
      max_paths: 32
      neighbors:
      - multihop: null
        neighbor: 9.9.9.2
        remote_as: 65000
      networks:
      - 50.50.50.1/32
      - 50.0.1.1/32
      purge: false
      router_id: 50.50.50.1
      state: present
      vrf: default
  item:
    bgp_neigh: 9.9.9.2
    ipv4: 9.9.9.1/24
    name: Eth1/14
  msg: |-
    router bgp 65001 vrf default addres -family l2vpn-evpn auto-create
    % Unrecognized command "auto-create".
    Type "router bgp 65001 vrf default address-family l2vpn-evpn ?" for help.
    mlx-2740-51 [mlag-group1: master] (config) #
```
After fix in PR:

```
TASK [vxlan_underlay : Configure BGP session to spines] **************************************************************************************************************
task path: /home/cumulus/Onyx_Lab/roles/vxlan_underlay/tasks/main.yml:19
Friday 11 March 2022  16:33:40 -0500 (0:00:02.581)       0:02:52.377 **********
<10.188.71.129> ESTABLISH LOCAL CONNECTION FOR USER: cumulus
<10.188.71.129> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88 `"&& mkdir "` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391 `" && echo ansible-tmp-1647034420.910151-12817-264932829745391="` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391 `" ) && sleep 0'
Using module file /home/cumulus/onyx_test/lib/python3.8/site-packages/ansible/modules/network/onyx/onyx_bgp.py
<10.188.71.129> PUT /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/tmpxgky33z_ TO /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391/AnsiballZ_onyx_bgp.py
<10.188.71.129> EXEC /bin/sh -c 'chmod u+x /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391/ /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391/AnsiballZ_onyx_bgp.py && sleep 0'
<10.188.71.129> EXEC /bin/sh -c '/usr/bin/python3 /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391/AnsiballZ_onyx_bgp.py && sleep 0'
<10.188.71.129> EXEC /bin/sh -c 'rm -f -r /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034420.910151-12817-264932829745391/ > /dev/null 2>&1 && sleep 0'
<10.188.71.129> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88 `"&& mkdir "` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034432.3282065-12817-183594815541995 `" && echo ansible-tmp-1647034432.3282065-12817-183594815541995="` echo /home/cumulus/.ansible/tmp/ansible-local-12073jwlyod88/ansible-tmp-1647034432.3282065-12817-183594815541995 `" ) && sleep 0'
changed: [mlx-2740-51] => (item={'name': 'Eth1/14', 'ipv4': '9.9.9.1/24', 'bgp_neigh': '9.9.9.2'}) => changed=true
  ansible_loop_var: item
  commands:
  - router bgp 65001 vrf default
  - exit
  - router bgp 65001 vrf default router-id 50.50.50.1 force
  - router bgp 65001 vrf default bgp fast-external-fallover
  - router bgp 65001 vrf default maximum-paths 32
  - router bgp 65001 vrf default bestpath as-path multipath-relax force
  - router bgp 65001 vrf default neighbor evpn peer-group
  - router bgp 65001 vrf default neighbor evpn send-community extended
  - router bgp 65001 vrf default address-family l2vpn-evpn neighbor evpn next-hop-unchanged
  - router bgp 65001 vrf default address-family l2vpn-evpn neighbor evpn activate
  - router bgp 65001 vrf default address-family l2vpn-evpn vni auto-create
  - router bgp 65001 vrf default neighbor 9.9.9.2 remote-as 65000
  - router bgp 65001 vrf default neighbor 9.9.9.2 peer-group evpn
  - router bgp 65001 vrf default network 50.50.50.1 /32
  - router bgp 65001 vrf default network 50.0.1.1 /32
  invocation:
    module_args:
      as_number: 65001
      ecmp_bestpath: true
      evpn: true
      fast_external_fallover: true
      max_paths: 32
      neighbors:
      - multihop: null
        neighbor: 9.9.9.2
        remote_as: 65000
      networks:
      - 50.50.50.1/32
      - 50.0.1.1/32
      purge: false
      router_id: 50.50.50.1
      state: present
      vrf: default
  item:
    bgp_neigh: 9.9.9.2
    ipv4: 9.9.9.1/24
    name: Eth1/14
```