### PR TITLE
Minor bug in example.

### DIFF
--- a/plugins/modules/onyx_lldp.py
+++ b/plugins/modules/onyx_lldp.py
@@ -29,7 +29,7 @@ EXAMPLES = """
 
 - name: Disable LLDP protocol
   onyx_lldp:
-    state: lldp
+    state: absent
 """
 
 RETURN = """


### PR DESCRIPTION
The examples at https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_lldp_module.html says:


```
- name: Enable LLDP protocol
  onyx_lldp:
    state: present

- name: Disable LLDP protocol
  onyx_lldp:
    state: lldp
```

That last "state: lldp" should be "state: absent" according to above documentation, and also testing.